### PR TITLE
feat: add WhatsApp sending support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,2 @@
-# Ignorer logs et fichiers temporaires
-*.log
-__pycache__/
-.ipynb_checkpoints/
-
-# Ignorer fichiers spécifiques
-bot.log
+secrets.json
+.env

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Wrapper module for the jokes bot."""
+
+from b import main
+
+if __name__ == "__main__":
+    main()

--- a/secrets.example.json
+++ b/secrets.example.json
@@ -1,0 +1,8 @@
+{
+  "TELEGRAM_BOT_TOKEN": "",
+  "TELEGRAM_CHAT_ID": "",
+  "TWILIO_ACCOUNT_SID": "",
+  "TWILIO_AUTH_TOKEN": "",
+  "WHATSAPP_FROM": "",
+  "WHATSAPP_TO": ""
+}


### PR DESCRIPTION
## Summary
- add Twilio/WhatsApp message sending
- expose script via bot.py wrapper
- load messaging credentials from secrets file

## Testing
- `python -m py_compile b.py bot.py`
- `python test_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_689e595fbafc8327889dd31e944d19cf