### PR TITLE
Split jokes into two Telegram messages

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -52,6 +52,8 @@ def get_joke_fr() -> str:
         setup = data.get("setup", "").strip()
         delivery = data.get("delivery", "").strip()
         if setup or delivery:
+            if setup.endswith("?"):
+                return f"{setup} … {delivery}"
             return f"{setup} ... {delivery}"
         return "Pas de blague disponible 😅"
     except Exception as e:
@@ -69,6 +71,17 @@ def send_telegram_message(token: str, chat_id: str, text: str) -> None:
                 _log(f"Telegram a répondu {resp.status}")
     except Exception as e:
         _log(f"Erreur d'envoi Telegram : {e}")
+
+
+def send_joke(token: str, chat_id: str, joke: str, delay: int = 4) -> None:
+    """Envoie une blague en deux parties si elle contient "? …"."""
+    if "? …" in joke:
+        part1, part2 = joke.split("? …", 1)
+        send_telegram_message(token, chat_id, part1.strip() + " ?")
+        time.sleep(delay)
+        send_telegram_message(token, chat_id, part2.strip())
+    else:
+        send_telegram_message(token, chat_id, joke)
 
 def handle_signal(signum, frame):
     global RUNNING
@@ -104,7 +117,7 @@ def main():
     interval = max(1, INTERVAL_MINUTES) * 60
     while RUNNING:
         joke = get_joke_fr()
-        send_telegram_message(BOT_TOKEN, CHAT_ID, joke)
+        send_joke(BOT_TOKEN, CHAT_ID, joke)
         for _ in range(interval):
             if not RUNNING:
                 break


### PR DESCRIPTION
## Summary
- add helper to split jokes on `? …` and send parts
- pause 4s before sending punchline
- ensure two-part jokes from API include ellipsis after question so the split works

## Testing
- `python test_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_689e58fd43808327aebcf98a98b3d8e3